### PR TITLE
Implement eigsh and a basic test

### DIFF
--- a/mdsa/algorithms/eigsh.py
+++ b/mdsa/algorithms/eigsh.py
@@ -1,0 +1,20 @@
+from scipy.sparse.linalg import eigsh
+
+from mdsa.algorithm import Algorithm
+
+"""
+ Perform matrix decomposition using eigsh routine.
+"""
+
+
+class Eigsh(Algorithm):
+    def __init__(self):
+        super(Eigsh, self).__init__(algorithm_name='eigsh')
+
+    def run(self, distance_matrix, num_dimensions_out=10):
+        super(Eigsh, self).run(distance_matrix, num_dimensions_out)
+
+        eigenvalues, eigenvectors = eigsh(distance_matrix,
+                                          k=num_dimensions_out)
+
+        return eigenvectors, eigenvalues

--- a/mdsa/tests/test_eigsh.py
+++ b/mdsa/tests/test_eigsh.py
@@ -1,0 +1,27 @@
+import unittest
+
+import numpy as np
+from skbio.util import get_data_path
+
+from mdsa.algorithms.eigsh import Eigsh
+
+
+class TestEigsh(unittest.TestCase):
+    def setUp(self):
+        self.test_matrix = np.loadtxt(get_data_path('full_sym_matrix.txt'))
+        self.eigsh = Eigsh()
+
+    def test_eigsh(self):
+        """
+        Ensure eigenvalues and eigenvectors are returned.
+        """
+        DIMENSIONS_OUT = 10
+        eigenvectors, eigenvalues = self.eigsh.run(self.test_matrix,
+                                                   DIMENSIONS_OUT)
+
+        self.assertEqual(eigenvectors.shape, (100, DIMENSIONS_OUT))
+        self.assertEqual(eigenvalues.shape, (DIMENSIONS_OUT,))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/mdsa
+++ b/scripts/mdsa
@@ -8,18 +8,21 @@ import numpy as np
 from skbio import DistanceMatrix
 
 from mdsa.algorithm import Algorithm
+from mdsa.algorithms.eigsh import Eigsh
 from mdsa.algorithms.fsvd import FSVD
 from mdsa.algorithms.nystrom import Nystrom
 from mdsa.algorithms.scmds import Scmds
 
-# Register algorithms here
 from mdsa.algorithms.svd import SVD
 from mdsa.pcoa import pcoa
 
+# Register algorithms here so they can be called
+# from the command line
 Algorithm.register(Nystrom())
 Algorithm.register(Scmds())
 Algorithm.register(SVD())
 Algorithm.register(FSVD())
+Algorithm.register(Eigsh())
 
 
 @click.group()


### PR DESCRIPTION
Good news: output very close to reference pcoa output (differences only in the hundredths place `0.0x`).

ref

```
Eigvals 9
0.527576831536  0.380955902485  0.302541529797  0.266409397663  0.255696353121  0.222923562728  0.202538724053  0.191550929645  0.0

Proportion explained    9
0.2244823211    0.162095566209  0.12873049152   0.113356380295  0.108798012753  0.0948532911187 0.0861796048848 0.081504332119  0.0

Species 0   0

Site    9   9
10086.PC.481    -0.0705337512946    -0.0523255833501    0.430931391656  -0.116746630305 0.140169551454  -0.0121985776207    -0.144852652533 0.0708443496647 -0.0
10086.PC.593    -0.15252345786  -0.367119659406 -0.0488310385909    0.286852415403  -0.122137624507 0.0234169453317 -0.141457741587 -0.0529995496517    -0.0
10086.PC.356    -0.310268662031 0.202957439323  -0.161995239726 -0.0244935105553    0.15035822631   -0.249882413934 -0.0749673365754    -0.147145848302 -0.0
10086.PC.355    -0.181535837645 0.280265981912  -0.0544393413007    0.0939578745749 0.0589143460999 0.352680352153  0.0046686377854 0.0329116944137 -0.0
10086.PC.354    -0.306665965365 -0.0701963718488    0.0407228466959 -0.1114824179   -0.201732274725 -0.0620072371812    0.284898055936  0.114474970493  -0.0
10086.PC.636    0.305648978048  0.0979331334515 -0.0703076036076    0.203718428091  0.0923240786186 -0.145946437069 0.0358828025594 0.269537748495  -0.0
10086.PC.635    0.226649045655  0.135140021056  -0.0831332541419    -0.198963114956 -0.313113479926 -0.000656969485293  -0.195494992339 0.00207851498269    -0.0
10086.PC.607    0.168428915044  -0.293927672225 -0.214003498911 -0.237780522122 0.217479735297  0.101065266217  0.0505607098618 -0.0158839896734    -0.0
10086.PC.634    0.320800735448  0.0672727110869 0.161055737927  0.10493747777   -0.022262558621 -0.00647092841082   0.180762516892  -0.273817890423 -0.0

Biplot  0   0

Site constraints    0   0
```

eigsh

```
Eigvals 8
0.527576831536  0.380955902485  0.302541529797  0.266409397663  0.255696353121  0.222923562728  0.202538724053  0.191550929645

Proportion explained    8
0.2244823211    0.162095566209  0.12873049152   0.113356380295  0.108798012753  0.0948532911187 0.0861796048848 0.081504332119

Species 0   0

Site    9   8
10086.PC.481    -0.0748123407644    -0.0554996622246    -0.457071763899 -0.123828500954 0.148672260524  -0.0129385454347    0.153639439319  0.075141780085
10086.PC.593    -0.161775557014 -0.389389201009 0.05179313778   0.304252932196  -0.12954651379  0.024837421258  0.150038592491  -0.0562145114378
10086.PC.356    -0.329089612367 0.215268872456  0.171821898795  -0.0259792911131    0.159478982146  -0.265040324088 0.07951486809   -0.156071740736
10086.PC.355    -0.192547832741 0.297266964519  0.0577416410956 0.0996573753867 0.0624881004546 0.374074002898  -0.00495183815544   0.0349081234504
10086.PC.354    -0.325268375504 -0.0744544958235    -0.0431931015719    -0.118244960521 -0.213969389164 -0.0657686068402    -0.302180020949 0.121419041868
10086.PC.636    0.324189697561  0.10387377415   0.0745724749199 0.216076022934  0.097924473087  -0.154799573013 -0.0380594595266    0.28588795462
10086.PC.635    0.240397615698  0.143337637947  0.0881761316188 -0.211032251687 -0.332106997405 -0.000696821367125  0.207353752156  0.00220459805859
10086.PC.607    0.178645841964  -0.311757375313 0.226984987916  -0.252204329439 0.230672093399  0.107195902626  -0.0536277312073    -0.0168475152155
10086.PC.634    0.340260563168  0.0713534852975 -0.170825406655 0.111303003198  -0.0236130092512    -0.00686345603979   -0.191727602218 -0.290427730692

Biplot  0   0

Site constraints    0   0
```
